### PR TITLE
(GH-1162) Expand dir path relative to Boltdir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Release 0.2.0
+
+### Bug fixes
+
+* **Expand `dir` path relative to Boltdir** ([#1162](https://github.com/puppetlabs/bolt/issues/1162))
+
+  The `dir` option will now be expanded relative to the active Boltdir the user is running bolt with, instead of the current working directory they ran Bolt from. This is part of standardizing all configurable paths in Bolt to be relative to the Boltdir.
+
 ## Release 0.1.0
 
 This is the initial release.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You will need to have installed `Terraform` on the system you wish to run bolt f
 
 The Terraform plugin supports looking up target objects from a Terraform state file. It accepts several fields:
 
--   `dir`: The directory containing either a local Terraform state file or Terraform configuration to read remote state from.
+-   `dir`: The directory containing either a local Terraform state file or Terraform configuration to read remote state from. Relative to the active Boltdir unless absolute path is specified.
 -   `resource_type`: The Terraform resources to match, as a regular expression.
 -   `uri`: (Optional) The property of the Terraform resource to use as the target URI.
 -   `statefile`: (Optional) The name of the local Terraform state file to load, relative to `dir` (defaults to `terraform.tfstate)`.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-terraform",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Puppet, Inc.",
   "summary": "A task to generate Bolt inventory from Terraform statefiles",
   "license": "Apache-2.0",

--- a/spec/tasks/resolve_reference_spec.rb
+++ b/spec/tasks/resolve_reference_spec.rb
@@ -22,6 +22,14 @@ describe Terraform do
 
       expect(state).to eq(JSON.parse(File.read(statefile)))
     end
+
+    it 'expands the dir relative to the Boltdir' do
+      statefile = File.join(terraform_dir, 'empty.tfstate')
+      state = subject.load_statefile(dir: '.',
+                                     statefile: 'empty.tfstate',
+                                     _boltdir: terraform_dir)
+      expect(state).to eq(JSON.parse(File.read(statefile)))
+    end
   end
 
   shared_examples('loading terraform targets') do

--- a/tasks/resolve_reference.rb
+++ b/tasks/resolve_reference.rb
@@ -42,7 +42,7 @@ class Terraform < TaskHelper
 
   # Uses the Terraform CLI to pull remote state files
   def load_remote_statefile(opts)
-    dir = File.expand_path(opts[:dir])
+    dir = File.expand_path(opts[:dir], opts[:_boltdir])
 
     begin
       stdout_str, stderr_str, status = Open3.capture3('terraform state pull', chdir: dir)
@@ -65,9 +65,8 @@ class Terraform < TaskHelper
   end
 
   def load_local_statefile(opts)
-    dir = opts[:dir]
     filename = opts.fetch(:statefile, 'terraform.tfstate')
-    File.read(File.expand_path(File.join(dir, filename)))
+    File.read(File.expand_path(File.join(opts[:dir], filename), opts[:_boltdir]))
   rescue StandardError => e
     msg = "Could not load Terraform state file #{filename}: #{e}"
     raise TaskHelper::Error.new(msg, 'bolt-plugin/validation-error')


### PR DESCRIPTION
As part of standardizing configurable paths to be relative to the
Boltdir (if they're not absolute), the `dir` config is now expanded
relative to the `_boltdir` option that's passed in rather than the
current working directory.