### PR TITLE
avoid browser warnings in source URL

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,7 @@
   "author": "Puppet, Inc.",
   "summary": "A task to generate Bolt inventory from Terraform statefiles",
   "license": "Apache-2.0",
-  "source": "git@github.com/puppetlabs/puppetlabs-terraform",
+  "source": "https://github.com/puppetlabs/puppetlabs-terraform",
   "dependencies": [
 
   ],


### PR DESCRIPTION
the source URL in metadata.json is most commonly interpreted as a web page. As it is specified this leads to a lot of security warnings, when clicking the link on the forge.

This commit fixes that.