### PR TITLE
(DO NOT MERGE)(GH-1405) Convert resolve_reference task to use ruby_plugin_helper

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,3 +3,6 @@ fixtures:
     facts:
       repo: "puppetlabs/ruby_task_helper"
       ref: "0.4.0"
+    ruby_plugin_helper:
+      repo: "puppetlabs/ruby_plugin_helper"
+      ref: "0.1.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
 
 before_install:
 - git clone https://github.com/puppetlabs/puppetlabs-ruby_task_helper ../ruby_task_helper
+- git clone https://github.com/puppetlabs/puppetlabs-ruby_plugin_helper ../ruby_plugin_helper
 - curl -fSL "https://releases.hashicorp.com/terraform/0.12.13/terraform_0.12.13_linux_amd64.zip" -o terraform.zip
 - sudo unzip terraform.zip -d /opt/terraform
 - sudo ln -s /opt/terraform/terraform /usr/bin/terraform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Release 0.3.0
+
+## New features
+
+* **Added `target_mapping` parameter in `resolve_reference` task** ([#1405](https://github.com/puppetlabs/bolt/issues/1405))
+
+  The `resolve_reference` task has a new `target_mapping` parameter that accepts a hash of target attributes and the resource values to populate them with.
+
+* **Added `state` parameter in the `resolve_reference` task** ([#1405](https://github.com/puppetlabs/bolt/issues/1405))
+
+  The `statefile` parameter for the `resolve_reference` task has been replaced with a `state` parameter to maintain consistency among the other tasks and plans in the module.
+
 ## Release 0.2.0
 
 ### Bug fixes

--- a/README.md
+++ b/README.md
@@ -20,13 +20,11 @@ The `resolve_reference` task supports looking up target objects from a Terraform
 
 -   `dir`: The directory containing either a local Terraform state file or Terraform configuration to read remote state from. Relative to the active Boltdir unless absolute path is specified.
 -   `resource_type`: The Terraform resources to match, as a regular expression.
--   `uri`: (Optional) The property of the Terraform resource to use as the target URI.
--   `statefile`: (Optional) The name of the local Terraform state file to load, relative to `dir` (defaults to `terraform.tfstate)`.
--   `name`: (Optional) The property of the Terraform resource to use as the target name.
--   `config`: A Bolt config map where each value is the Terraform property to use for that config setting.
+-   `state`: (Optional) The name of the local Terraform state file to load, relative to `dir` (defaults to `terraform.tfstate)`.
 -   `backend`: (Optional) The type of backend to load the state form, either `remote` or `local` (defaults to `local`).
+-   `target_mapping`: A hash of target attributes to populate with resource values (e.g. `target_mapping: { name: 'id' }`).
 
-Either `uri` or `name` is required. If only `uri` is set, the value of `uri` is used as the `name`.
+The `target_mapping` parameter requires either a `uri` or `name` field. If only `uri` is set, the value of `uri` is used as the `name`.
 
 ### Examples
 
@@ -37,11 +35,13 @@ groups:
       - _plugin: terraform
         dir: /path/to/terraform/project1
         resource_type: google_compute_instance.web
-        uri: network_interface.0.access_config.0.nat_ip
+        target_mapping:
+          uri: network_interface.0.access_config.0.nat_ip
       - _plugin: terraform
         dir: /path/to/terraform/project2
         resource_type: aws_instance.web
-        uri: public_ip
+        target_mapping:
+          uri: public_ip
 ```
 
 Multiple resources with the same name are identified as <resource>.0, <resource>.1, etc.

--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,8 @@
   "license": "Apache-2.0",
   "source": "https://github.com/puppetlabs/puppetlabs-terraform",
   "dependencies": [
-
+    {"name":"puppetlabs-ruby_task_helper","version_requirement":">= 0.1.0 < 1.0.0"},
+    {"name":"puppetlabs-ruby_plugin_helper","version_requirement":">= 0.1.0 <= 1.0.0"}
   ],
   "operatingsystem_support": [
     {

--- a/spec/fixtures/docker_provision/terraform.tfstate
+++ b/spec/fixtures/docker_provision/terraform.tfstate
@@ -1,7 +1,7 @@
 {
   "version": 4,
-  "terraform_version": "0.12.10",
-  "serial": 528,
+  "terraform_version": "0.12.13",
+  "serial": 844,
   "lineage": "bdb4dc29-4796-d16c-6435-6c6d8c0e765f",
   "outputs": {},
   "resources": []

--- a/spec/integration/resolve_reference_spec.rb
+++ b/spec/integration/resolve_reference_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/run'
+require 'open3'
+
+describe 'terraform::resolve_reference' do
+  include BoltSpec::Run
+
+  let(:bolt_config) { { 'modulepath' => RSpec.configuration.module_path } }
+  let(:terraform_dir) { File.join(RSpec.configuration.module_path, '../docker_provision') }
+  let(:resource_type) { 'docker_container' }
+
+  let(:expected_result) do
+    {
+      'value' => [
+        { 'uri' => '0.0.0.0',
+          'config' => { 'ssh' => { 'port' => 2200 } } }
+      ]
+    }
+  end
+
+  let(:target_mapping) do
+    {
+      'uri' => 'ports.0.ip',
+      'config' => {
+        'ssh' => {
+          'port' => 'ports.0.external'
+        }
+      }
+    }
+  end
+
+  let(:params) do
+    {
+      'dir' => terraform_dir,
+      'resource_type' => resource_type,
+      'target_mapping' => target_mapping
+    }
+  end
+
+  let(:inventory) do
+    {
+      'version' => 2,
+      'groups' => [
+        { 'name' => 'terraform',
+          'targets' => [
+            { '_plugin' => 'terraform',
+              'dir' => terraform_dir,
+              'resource_type' => resource_type,
+              'target_mapping' => target_mapping }
+          ],
+          'config' => {
+            'transport' => 'ssh',
+            'ssh' => {
+              'user' => 'root',
+              'password' => 'root',
+              'host-key-check' => false
+            }
+          } }
+      ]
+    }
+  end
+
+  before(:all) do
+    terraform_dir = File.join(RSpec.configuration.module_path, '../docker_provision')
+    _out, _err, status = Open3.capture3('terraform init', chdir: terraform_dir)
+    expect(status).to eq(0)
+    _out, _err, status = Open3.capture3('terraform apply -auto-approve', chdir: terraform_dir)
+    expect(status).to eq(0)
+  end
+
+  after(:all) do
+    terraform_dir = File.join(RSpec.configuration.module_path, '../docker_provision')
+    _out, _err, status = Open3.capture3('terraform destroy -auto-approve', chdir: terraform_dir)
+    expect(status).to eq(0)
+  end
+
+  it 'resolves references from an applied terraform manifest' do
+    result = run_task('terraform::resolve_reference', 'localhost', params)
+    expect(result.first['result']).to eq(expected_result)
+  end
+
+  it 'runs a command on a discovered target' do
+    result = run_command('whoami', 'terraform', inventory: inventory)
+    expect(result.first['result']['stdout']).to match(/root/)
+  end
+end

--- a/spec/plans/apply_spec.rb
+++ b/spec/plans/apply_spec.rb
@@ -14,7 +14,8 @@ describe "terraform::apply" do
       'target' => 'foo',
       'var' => { 'foo' => 'bar' },
       'var_file' => 'foo'
-    } }
+    }
+  }
   let(:bolt_config) { { 'modulepath' => RSpec.configuration.module_path } }
   let(:apply_result) { { 'stdout' => 'Terraform logs' } }
   let(:output_result) { { 'my' => 'output' } }

--- a/spec/plans/destroy_spec.rb
+++ b/spec/plans/destroy_spec.rb
@@ -14,7 +14,8 @@ describe "terraform::destroy" do
       'target' => 'foo',
       'var' => { 'foo' => 'bar' },
       'var_file' => 'foo'
-    } }
+    }
+  }
   let(:bolt_config) { { 'modulepath' => RSpec.configuration.module_path } }
   let(:destroy_result) { { 'stdout' => 'Terraform logs' } }
 

--- a/tasks/resolve_reference.json
+++ b/tasks/resolve_reference.json
@@ -1,6 +1,9 @@
 {
   "description": "Generate targets from Terraform Statefile",
-  "files": ["ruby_task_helper/files/task_helper.rb"],
+  "files": [
+    "ruby_task_helper/files/task_helper.rb",
+    "ruby_plugin_helper/lib/plugin_helper.rb"
+  ],
   "input_method": "stdin",
   "parameters": {
     "dir": {
@@ -9,20 +12,14 @@
     "resource_type": {
       "type": "String[1]"
     },
-    "statefile": {
+    "state": {
       "type": "Optional[String[1]]"
     },
     "backend": {
       "type": "Optional[String[1]]"
     },
-    "uri": {
-      "type": "Optional[String[1]]"
-    },
-    "name": {
-      "type": "Optional[String[1]]"
-    },
-    "config": {
-      "type": "Optional[Hash]"
+    "target_mapping": {
+      "type": "Hash"
     }
   }
 }


### PR DESCRIPTION
This updates the `resolve_reference` task to use the ruby plugin helper
to perform operations common to Bolt plugins, such as mapping resource
values to target data.

It replaces several methods that were part of the task with those in the
plugin helper.

It also replaces the `statefile` parameter for the `resolve_reference` task
with a `state` parameter to maintain consistency among the tasks and
plans in the module.

### TODO
 - [x] Update `.fixtures.yml` when `ruby_plugin_helper` is on the forge