### PR TITLE
(GH-1436) Raise error when remote state cannot be loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
   The `statefile` parameter for the `resolve_reference` task has been replaced with a `state` parameter to maintain consistency among the other tasks and plans in the module.
 
+### Bug fixes
+
+* **Raise error when remote state cannot be loaded** ([#1436](https://github.com/puppetlabs/bolt/issues/1436))
+
+  When attempting to load remote state from a non-existent state file, `terraform` would return a `nil` value which would be loaded into the inventory and cause Bolt to error. The `terraform` plugin now checks whether the attempt to load remote state returned any data and errors if it did not.
+
 ## Release 0.2.0
 
 ### Bug fixes

--- a/spec/fixtures/docker_provision/terraform.tfstate
+++ b/spec/fixtures/docker_provision/terraform.tfstate
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "terraform_version": "0.12.13",
-  "serial": 844,
+  "serial": 904,
   "lineage": "bdb4dc29-4796-d16c-6435-6c6d8c0e765f",
   "outputs": {},
   "resources": []

--- a/spec/integration/resolve_reference_spec.rb
+++ b/spec/integration/resolve_reference_spec.rb
@@ -10,6 +10,7 @@ describe 'terraform::resolve_reference' do
   let(:bolt_config) { { 'modulepath' => RSpec.configuration.module_path } }
   let(:terraform_dir) { File.join(RSpec.configuration.module_path, '../docker_provision') }
   let(:resource_type) { 'docker_container' }
+  let(:backend) { 'local' }
 
   let(:expected_result) do
     {
@@ -48,6 +49,7 @@ describe 'terraform::resolve_reference' do
             { '_plugin' => 'terraform',
               'dir' => terraform_dir,
               'resource_type' => resource_type,
+              'backend' => backend,
               'target_mapping' => target_mapping }
           ],
           'config' => {
@@ -62,27 +64,40 @@ describe 'terraform::resolve_reference' do
     }
   end
 
-  before(:all) do
-    terraform_dir = File.join(RSpec.configuration.module_path, '../docker_provision')
-    _out, _err, status = Open3.capture3('terraform init', chdir: terraform_dir)
-    expect(status).to eq(0)
-    _out, _err, status = Open3.capture3('terraform apply -auto-approve', chdir: terraform_dir)
-    expect(status).to eq(0)
+  context 'with a local state file' do
+    before(:all) do
+      terraform_dir = File.join(RSpec.configuration.module_path, '../docker_provision')
+      _out, _err, status = Open3.capture3('terraform init', chdir: terraform_dir)
+      expect(status).to eq(0)
+      _out, _err, status = Open3.capture3('terraform apply -auto-approve', chdir: terraform_dir)
+      expect(status).to eq(0)
+    end
+
+    after(:all) do
+      terraform_dir = File.join(RSpec.configuration.module_path, '../docker_provision')
+      _out, _err, status = Open3.capture3('terraform destroy -auto-approve', chdir: terraform_dir)
+      expect(status).to eq(0)
+    end
+
+    it 'resolves references from an applied terraform manifest' do
+      result = run_task('terraform::resolve_reference', 'localhost', params)
+      expect(result.first['result']).to eq(expected_result)
+    end
+
+    it 'runs a command on a discovered target' do
+      result = run_command('whoami', 'terraform', inventory: inventory)
+      expect(result.first['result']['stdout']).to match(/root/)
+    end
   end
 
-  after(:all) do
-    terraform_dir = File.join(RSpec.configuration.module_path, '../docker_provision')
-    _out, _err, status = Open3.capture3('terraform destroy -auto-approve', chdir: terraform_dir)
-    expect(status).to eq(0)
-  end
+  context 'with a remote state file' do
+    let(:backend) { 'remote' }
+    let(:terraform_dir) { '.' }
 
-  it 'resolves references from an applied terraform manifest' do
-    result = run_task('terraform::resolve_reference', 'localhost', params)
-    expect(result.first['result']).to eq(expected_result)
-  end
-
-  it 'runs a command on a discovered target' do
-    result = run_command('whoami', 'terraform', inventory: inventory)
-    expect(result.first['result']['stdout']).to match(/root/)
+    it 'errors when a remote state file is not found' do
+      expect { run_command('whoami', 'terraform', inventory: inventory) }.to raise_error(
+        /Could not pull Terraform remote state file/
+      )
+    end
   end
 end

--- a/tasks/resolve_reference.rb
+++ b/tasks/resolve_reference.rb
@@ -58,9 +58,9 @@ class Terraform < TaskHelper
       raise TaskHelper::Error.new(msg, 'bolt-plugin/validation-error')
     end
 
-    unless status.success?
+    unless status.success? && !stdout_str.empty?
       err = stdout_str + stderr_str
-      msg = "Could not pull Terraform remote state file for #{opts[:dir]}:\n#{err}"
+      msg = "Could not pull Terraform remote state file for #{dir}:\n#{err}"
       raise TaskHelper::Error.new(msg, 'bolt-plugin/validation-error')
     end
 
@@ -71,7 +71,7 @@ class Terraform < TaskHelper
     filename = opts.fetch(:state, 'terraform.tfstate')
     File.read(File.expand_path(File.join(opts[:dir], filename), opts[:_boltdir]))
   rescue StandardError => e
-    msg = "Could not load Terraform state file #{filename}: #{e}"
+    msg = "Could not load Terraform state file #{filename}:\n#{e}"
     raise TaskHelper::Error.new(msg, 'bolt-plugin/validation-error')
   end
 


### PR DESCRIPTION
This fixes a bug that raises an obscure error caused by an attempt to
load a non-existent state file. Previously, if remote state could not be
loaded, `terraform state pull` would return successfully with a `nil`
value. This value would be loaded into the inventory, causing Bolt to
raise an error. Now, the plugin will check that `terraform state pull`
not only returned successfully but that it also returned data to act on.

Fixes puppetlabs/bolt#1436