### PR TITLE
(GH-1360) Allow multiple var-file CLI opts

### DIFF
--- a/lib/cli_helper.rb
+++ b/lib/cli_helper.rb
@@ -34,7 +34,11 @@ module CliHelper
 
       opts[:var].each { |k, v| cli_opts << "-var '#{k}=#{v}'" } if opts[:var]
 
-      cli_opts << "-var-file=#{File.expand_path(opts[:var_file], dir)}" if opts[:var_file]
+      if opts[:var_file]
+        var_file_paths = opts[:var_file].is_a?(Array) ? opts[:var_file] : Array(opts[:var_file])
+        var_file_paths.each { |path| cli_opts << "-var-file=#{File.expand_path(path, dir)}" }
+      end
+
       cli_opts.join(' ')
     end
   end

--- a/plans/apply.pp
+++ b/plans/apply.pp
@@ -3,7 +3,7 @@ plan terraform::apply(
 	Optional[String[1]] $state = undef,
 	Optional[Variant[String[1], Array[String[1]]]] $target = undef,
 	Optional[Hash] $var = undef,
-	Optional[String[1]] $var_file = undef,
+	Optional[Variant[String[1], Array[String[1]]]] $var_file = undef,
 	Optional[Boolean] $return_output = false
   ) {
 

--- a/plans/destroy.pp
+++ b/plans/destroy.pp
@@ -3,7 +3,7 @@ plan terraform::destroy(
 	Optional[String[1]] $state = undef,
 	Optional[Variant[String[1], Array[String[1]]]] $target = undef,
 	Optional[Hash] $var = undef,
-	Optional[String[1]] $var_file = undef
+	Optional[Variant[String[1], Array[String[1]]]] $var_file = undef
   ) {
   	
   $opts = {

--- a/tasks/apply.json
+++ b/tasks/apply.json
@@ -20,8 +20,8 @@
       "description": "Set Terraform variables, expects a hash with key value pairs representing variables and values."
     },
     "var_file": {
-      "type": "Optional[String[1]]",
-      "description": "Set variables in the Terraform configuration from a file. Path is relative to \"dir\""
+      "type": "Optional[Variant[String[1], Array[String[1]]]]",
+      "description": "Set variables in the Terraform configuration from a file. Path is relative to \"dir\". Accepts a single var-file paths or an array of paths"
     }
   }
 }

--- a/tasks/apply.json
+++ b/tasks/apply.json
@@ -21,7 +21,7 @@
     },
     "var_file": {
       "type": "Optional[Variant[String[1], Array[String[1]]]]",
-      "description": "Set variables in the Terraform configuration from a file. Path is relative to \"dir\". Accepts a single var-file paths or an array of paths"
+      "description": "Set variables in the Terraform configuration from a file. Path is relative to \"dir\". Accepts a single var-file path or an array of paths"
     }
   }
 }

--- a/tasks/destroy.json
+++ b/tasks/destroy.json
@@ -20,8 +20,8 @@
       "description": "Set Terraform variables, expects a hash with key value pairs representing variables and values."
     },
     "var_file": {
-      "type": "Optional[String[1]]",
-      "description": "Set variables in the Terraform configuration from a file. Path is relative to \"dir\""
+      "type": "Optional[Variant[String[1], Array[String[1]]]]",
+      "description": "Set variables in the Terraform configuration from a file. Path is relative to \"dir\". Accepts a single var-file paths or an array of paths"
     }
   }
 }

--- a/tasks/destroy.json
+++ b/tasks/destroy.json
@@ -21,7 +21,7 @@
     },
     "var_file": {
       "type": "Optional[Variant[String[1], Array[String[1]]]]",
-      "description": "Set variables in the Terraform configuration from a file. Path is relative to \"dir\". Accepts a single var-file paths or an array of paths"
+      "description": "Set variables in the Terraform configuration from a file. Path is relative to \"dir\". Accepts a single var-file path or an array of paths"
     }
   }
 }


### PR DESCRIPTION
Similar to `target` resources there can be multiple `var-files` to parse and load vars from. This commit implemnets that for the `appy` and `destroy` tasks.