### PR TITLE
(GH-1360) Expose `state_out` parameter for apply/destroy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@
 .DS_Store
 /spec/fixtures/docker_provision/.terraform/
 /spec/fixtures/docker_provision/terraform.tfstate.backup
+/spec/fixtures/docker_provision/terraform.tfstate

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ The `apply` task will apply resources and return the logs printed to stdout. It 
 
 -   `dir`: (Optional) Path to Terraform project directory. Path is relative to CWD, unless an absolute path is specified.
 -   `state`: (Optional) Path to read and save state. Defaults to `terraform.tfstate`. Path is relative to `dir`.
+-   `state_out`: (Optional) Path to write state to that is different than `state`. This can be used to preserve the old state. Path is relative to `dir`.
 -   `target`: (Optional) Resource to target. Operation will be limited to this resource and its dependencies. Accepts a single resource string or an array of resources.
 -   `var`: (Optional) Set Terraform variables, expects a hash with key value pairs representing variables and values (NOTE: single quotes `'` are incompatible).
 -   `var_file`: (Optional) Set variables in the Terraform configuration from a file. Path is relative to `dir`.
@@ -114,7 +115,8 @@ The `apply` task will apply resources and return the logs printed to stdout. It 
 The `apply` plan will run the `apply` task against the `localhost` target and optionally return the result of the `output` task. It accepts several fields:
 
 -   `dir`: (Optional) Path to Terraform project directory. Path is relative to CWD, unless an absolute path is specified.
--   `state`: (Optional) Path to read and save state. Defaults to `terraform.tfstate`. Path is relative to `dir`
+-   `state`: (Optional) Path to read and save state. Defaults to `terraform.tfstate`. Path is relative to `dir`.
+-   `state_out`: (Optional) Path to write state to that is different than `state`. This can be used to preserve the old state. Path is relative to `dir`.
 -   `target`: (Optional) Resource to target. Operation will be limited to this resource and its dependencies. Accepts a single resource string or an array of resources.
 -   `var`: (Optional) Set Terraform variables, expects a hash with key value pairs representing variables and values (NOTE: single quotes `'` are incompatible).
 -   `var_file`: (Optional) Set variables in the Terraform configuration from a file. Path is relative to `dir`.
@@ -131,6 +133,7 @@ The `destroy` task will destroy resources and return the logs printed to stdout.
 
 -   `dir`: (Optional) Path to Terraform project directory. Path is relative to CWD, unless an absolute path is specified.
 -   `state`: (Optional) Path to read and save state. Defaults to `terraform.tfstate`. Path is relative to `dir`.
+-   `state_out`: (Optional) Path to write state to that is different than `state`. This can be used to preserve the old state. Path is relative to `dir`.
 -   `target`: (Optional) Resource to target. Operation will be limited to this resource and its dependencies. Accepts a single resource string or an array of resources.
 -   `var`: (Optional) Set Terraform variables, expects a hash with key value pairs representing variables and values (NOTE: single quotes `'` are incompatible).
 -   `var_file`: (Optional) Set variables in the Terraform configuration from a file. Path is relative to `dir`.
@@ -138,7 +141,8 @@ The `destroy` task will destroy resources and return the logs printed to stdout.
 The `destroy` plan will run the `destroy` task against the `localhost` and return it's result. It accepts several fields:
 
 -   `dir`: (Optional) Path to Terraform project directory. Path is relative to CWD, unless an absolute path is specified.
--   `state`: (Optional) Path to read and save state. Defaults to `terraform.tfstate`. Path is relative to `dir`
+-   `state`: (Optional) Path to read and save state. Defaults to `terraform.tfstate`. Path is relative to `dir`.
+-   `state_out`: (Optional) Path to write state to that is different than `state`. This can be used to preserve the old state. Path is relative to `dir`.
 -   `target`: (Optional) Resource to target. Operation will be limited to this resource and its dependencies. Accepts a single resource string or an array of resources.
 -   `var`: (Optional) Set Terraform variables, expects a hash with key value pairs representing variables and values (NOTE: single quotes `'` are incompatible).
 -   `var_file`: (Optional) Set variables in the Terraform configuration from a file. Path is relative to `dir`.

--- a/lib/cli_helper.rb
+++ b/lib/cli_helper.rb
@@ -26,6 +26,7 @@ module CliHelper
     def transcribe_to_cli(opts, dir = nil)
       cli_opts = %w[-auto-approve -no-color -input=false]
       cli_opts << "-state=#{File.expand_path(opts[:state], dir)}" if opts[:state]
+      cli_opts << "-state-out=#{File.expand_path(opts[:state_out], dir)}" if opts[:state_out]
 
       if opts[:target]
         resources = opts[:target].is_a?(Array) ? opts[:target] : Array(opts[:target])

--- a/plans/apply.pp
+++ b/plans/apply.pp
@@ -1,29 +1,31 @@
 plan terraform::apply(
-	Optional[String[1]] $dir = undef,
-	Optional[String[1]] $state = undef,
-	Optional[Variant[String[1], Array[String[1]]]] $target = undef,
-	Optional[Hash] $var = undef,
-	Optional[Variant[String[1], Array[String[1]]]] $var_file = undef,
-	Optional[Boolean] $return_output = false
-  ) {
+  Optional[String[1]] $dir = undef,
+  Optional[String[1]] $state = undef,
+  Optional[String[1]] $state_out = undef,
+  Optional[Variant[String[1], Array[String[1]]]] $target = undef,
+  Optional[Hash] $var = undef,
+  Optional[Variant[String[1], Array[String[1]]]] $var_file = undef,
+  Optional[Boolean] $return_output = false
+) {
 
   $apply_opts = {
-  	'dir' => $dir,
-  	'state' => $state,
-  	'target' => $target,
-  	'var' => $var,
-  	'var_file' => $var_file
+    'dir' => $dir,
+    'state' => $state,
+    'state_out' => $state_out,
+    'target' => $target,
+    'var' => $var,
+    'var_file' => $var_file
   }
 
   $apply_logs = run_task('terraform::apply', 'localhost', $apply_opts)
 
   unless $return_output {
-  	return $apply_logs
+    return $apply_logs
   }
 
   $output_opts = {
-  	'dir' => $dir,
-  	'state' => $state
+    'dir' => $dir,
+    'state' => $state
   }
 
   $output = run_task('terraform::output', 'localhost', $output_opts)

--- a/plans/destroy.pp
+++ b/plans/destroy.pp
@@ -1,17 +1,19 @@
 plan terraform::destroy(
-	Optional[String[1]] $dir = undef,
-	Optional[String[1]] $state = undef,
-	Optional[Variant[String[1], Array[String[1]]]] $target = undef,
-	Optional[Hash] $var = undef,
-	Optional[Variant[String[1], Array[String[1]]]] $var_file = undef
-  ) {
-  	
+  Optional[String[1]] $dir = undef,
+  Optional[String[1]] $state = undef,
+  Optional[String[1]] $state_out = undef,
+  Optional[Variant[String[1], Array[String[1]]]] $target = undef,
+  Optional[Hash] $var = undef,
+  Optional[Variant[String[1], Array[String[1]]]] $var_file = undef
+) {
+
   $opts = {
-  	'dir' => $dir,
-  	'state' => $state,
-  	'target' => $target,
-  	'var' => $var,
-  	'var_file' => $var_file
+    'dir' => $dir,
+    'state' => $state,
+    'state_out' => $state_out,
+    'target' => $target,
+    'var' => $var,
+    'var_file' => $var_file
   }
   $result = run_task('terraform::destroy', 'localhost', $opts)
   return $result

--- a/spec/fixtures/docker_provision/terraform.tfstate
+++ b/spec/fixtures/docker_provision/terraform.tfstate
@@ -1,8 +1,0 @@
-{
-  "version": 4,
-  "terraform_version": "0.12.13",
-  "serial": 904,
-  "lineage": "bdb4dc29-4796-d16c-6435-6c6d8c0e765f",
-  "outputs": {},
-  "resources": []
-}

--- a/spec/plans/apply_spec.rb
+++ b/spec/plans/apply_spec.rb
@@ -11,6 +11,7 @@ describe "terraform::apply" do
     {
       'dir' => 'foo',
       'state' => 'foo',
+      'state_out' => 'foo',
       'target' => 'foo',
       'var' => { 'foo' => 'bar' },
       'var_file' => 'foo'

--- a/spec/plans/destroy_spec.rb
+++ b/spec/plans/destroy_spec.rb
@@ -11,6 +11,7 @@ describe "terraform::destroy" do
     {
       'dir' => 'foo',
       'state' => 'foo',
+      'state_out' => 'foo',
       'target' => 'foo',
       'var' => { 'foo' => 'bar' },
       'var_file' => 'foo'

--- a/tasks/apply.json
+++ b/tasks/apply.json
@@ -22,6 +22,10 @@
     "var_file": {
       "type": "Optional[Variant[String[1], Array[String[1]]]]",
       "description": "Set variables in the Terraform configuration from a file. Path is relative to \"dir\". Accepts a single var-file path or an array of paths"
+    },
+    "state_out": {
+      "type": "Optional[String[1]]",
+      "description": "Path to write state to that is different than \"state\". This can be used to preserve the old state."
     }
   }
 }

--- a/tasks/destroy.json
+++ b/tasks/destroy.json
@@ -22,6 +22,10 @@
     "var_file": {
       "type": "Optional[Variant[String[1], Array[String[1]]]]",
       "description": "Set variables in the Terraform configuration from a file. Path is relative to \"dir\". Accepts a single var-file path or an array of paths"
+    },
+    "state_out": {
+      "type": "Optional[String[1]]",
+      "description": "Path to write state to that is different than \"state\". This can be used to preserve the old state."
     }
   }
 }


### PR DESCRIPTION
The state-out option helps store old state which can be usefull when dynamically creating and destroying resources durring plan execution.