### PR TITLE
(packaging) Resolve Gem dependency conflict for ship job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: ruby
 cache: bundler
 rvm:
 - 2.5
+env:
+- GEM_BOLT=true
 
 before_install:
 - git clone https://github.com/puppetlabs/puppetlabs-ruby_task_helper ../ruby_task_helper

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,10 @@ group :development do
   gem "puppet-module-posix-default-r#{minor_version}", require: false, platforms: [:ruby]
   gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby]
   gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])
+  # Automatic jenkins job to push to forge requires puppet 5 which is incompatible with modern bolt
+  if ENV['GEM_BOLT']
+    gem 'bolt', '~> 1', require: false
+  end
   # Pin puppet blacksmith to avoid failures in forge module push job
-  gem "bolt", "~> 1"
   gem "puppet-blacksmith", "4.1.2"
 end


### PR DESCRIPTION
The module ship to forge job requires puppet5 which is incompatible with modern bolt. Even though bolt is only a development dependency bundler still want to resolve it. This commit guards installing bolt on the presence of a `GEM_BOLT` environment variable similar to how it is handled in the puppet_agent module. https://github.com/puppetlabs/puppetlabs-puppet_agent/blob/749575b9558742bd781f110c4ff213cebf589cd3/Gemfile#L70-L73