### PR TITLE
Add simple initialization task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Release 0.4.0
+
+## New features
+
+* **Added `initialize` task**
+
+  There has been a simple `initialize` task added to the module that can be used to ensure Terraform project directories are initialized with required modules and providers installed so your code runs without manually running `terraform init` before executing a plan.
+
 ## Release 0.3.0
 
 ## New features

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ google_compute_instance.app.1:
 
 ## Setting up Terraform project directories
 
-The `initialize` task will setup a Terraform project directory with all the appropriate modules and providers needed to execute your configuration
+The `initialize` task will setup a Terraform project directory with all the appropriate modules and providers needed to execute your configuration. It accepts a single field:
 
 -   `dir`: (Optional) Path to Terraform project directory. Path is relative to CWD, unless an absolute path is specified.
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ google_compute_instance.app.1:
   zone = us-west1-a
 ```
 
+## Setting up Terraform project directories
+
+The `initialize` task will setup a Terraform project directory with all the appropriate modules and providers needed to execute your configuration
+
+-   `dir`: (Optional) Path to Terraform project directory. Path is relative to CWD, unless an absolute path is specified.
+
 ## Provisioning resources 
 
 The `apply` task will apply resources and return the logs printed to stdout. It accepts several fields:
@@ -154,6 +160,7 @@ In this example plan, resources are applied and then destroyed during plan execu
 
 ```puppet
 plan example(TargetSpec $targets){
+  run_task('terraform::initialize', 'dir' => '/home/cas/working_dir/dynamic-inventory-demo')
   $apply_result = run_plan('terraform::apply', 'dir' => '/home/cas/working_dir/dynamic-inventory-demo', 'return_output' => true)
   run_task('important::stuff', $targets, 'task_var' => $apply_result)
   run_plan('destroy', 'dir' => '/home/cas/working_dir/dynamic-inventory-demo')

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -13,9 +13,10 @@ describe 'terraform::apply' do
   let(:var_file) { 'tfvar_alternate.tfvars' }
 
   before(:all) do
+    bolt_config = { 'modulepath' => RSpec.configuration.module_path }
     terraform_dir = File.join(RSpec.configuration.module_path, '../docker_provision')
-    _out, _err, status = Open3.capture3('terraform init', chdir: terraform_dir)
-    expect(status).to eq(0)
+    result = run_task('terraform::initialize', 'localhost', { 'dir' => terraform_dir }, config: bolt_config)[0]
+    expect(result['status']).to eq('success')
   end
 
   after(:each) do

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -25,6 +25,12 @@ describe 'terraform::apply' do
     expect(status).to eq(0)
   end
 
+  after(:all) do
+    terraform_dir = File.join(RSpec.configuration.module_path, '../docker_provision')
+    _out, _err, status = Open3.capture3('rm -rf .terraform', chdir: terraform_dir)
+    expect(status).to eq(0)
+  end
+
   it "applies terraform manifest and returns logs" do
     result = run_plan('terraform::apply', 'dir' => terraform_dir)
     expect(result['status']).to eq('success')

--- a/spec/integration/destroy_spec.rb
+++ b/spec/integration/destroy_spec.rb
@@ -22,6 +22,12 @@ describe 'terraform::destroy' do
     expect(status).to eq(0)
   end
 
+  after(:all) do
+    terraform_dir = File.join(RSpec.configuration.module_path, '../docker_provision')
+    _out, _err, status = Open3.capture3('rm -rf .terraform', chdir: terraform_dir)
+    expect(status).to eq(0)
+  end
+
   it "destroys Terraform resources" do
     result = run_plan('terraform::destroy', 'dir' => terraform_dir)
     expect(result['status']).to eq('success')

--- a/spec/integration/destroy_spec.rb
+++ b/spec/integration/destroy_spec.rb
@@ -10,9 +10,10 @@ describe 'terraform::destroy' do
   let(:terraform_dir) { File.join(RSpec.configuration.module_path, '../docker_provision') }
 
   before(:all) do
+    bolt_config = { 'modulepath' => RSpec.configuration.module_path }
     terraform_dir = File.join(RSpec.configuration.module_path, '../docker_provision')
-    _out, _err, status = Open3.capture3('terraform init', chdir: terraform_dir)
-    expect(status).to eq(0)
+    result = run_task('terraform::initialize', 'localhost', { 'dir' => terraform_dir }, config: bolt_config)[0]
+    expect(result['status']).to eq('success')
   end
 
   before(:each) do

--- a/spec/integration/resolve_reference_spec.rb
+++ b/spec/integration/resolve_reference_spec.rb
@@ -77,6 +77,8 @@ describe 'terraform::resolve_reference' do
       terraform_dir = File.join(RSpec.configuration.module_path, '../docker_provision')
       _out, _err, status = Open3.capture3('terraform destroy -auto-approve', chdir: terraform_dir)
       expect(status).to eq(0)
+      _out, _err, status = Open3.capture3('rm -rf .terraform', chdir: terraform_dir)
+      expect(status).to eq(0)
     end
 
     it 'resolves references from an applied terraform manifest' do

--- a/spec/tasks/terraform_initialize_spec.rb
+++ b/spec/tasks/terraform_initialize_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../tasks/initialize.rb'
+
+describe TerraformInitialize do
+  describe "#initialize" do
+    let(:terraform_out) { "Terraform message" }
+    let(:check_err) { "" }
+    let(:check_code) { 1 }
+    let(:check_response) { [terraform_out, check_err, check_code] }
+    let(:init_err) { "" }
+    let(:init_code) { 0 }
+    let(:init_response) { [terraform_out, init_err, init_code] }
+    let(:expected_dir) { File.join(Dir.pwd, dir) }
+    let(:opts) { {} }
+    let(:success_result) { { stdout: terraform_out } }
+    let(:check_cli) { "terraform providers" }
+    let(:init_cli) { "terraform init -no-color" }
+
+    context "with no options specified" do
+      it 'Invokes terraform init with default args' do
+        expect(Open3).to receive(:capture3).with(check_cli).and_return(check_response)
+        expect(Open3).to receive(:capture3).with(init_cli).and_return(init_response)
+        result = subject.init(opts)
+        expect(result).to eq(success_result)
+      end
+    end
+
+    context "with dir option" do
+      let(:dir) { "foo/bar" }
+      let(:opts) { { dir: dir } }
+      it 'invokes terraform init with default args from dir relative to cwd' do
+        expected_dir = File.expand_path(dir)
+        expect(Open3).to receive(:capture3).with(check_cli, chdir: expected_dir).and_return(check_response)
+        expect(Open3).to receive(:capture3).with(init_cli, chdir: expected_dir).and_return(init_response)
+        result = subject.init(opts)
+        expect(result).to eq(success_result)
+      end
+    end
+  end
+end

--- a/spec/tasks/terraform_initialize_spec.rb
+++ b/spec/tasks/terraform_initialize_spec.rb
@@ -6,22 +6,17 @@ require_relative '../../tasks/initialize.rb'
 describe TerraformInitialize do
   describe "#initialize" do
     let(:terraform_out) { "Terraform message" }
-    let(:check_err) { "" }
-    let(:check_code) { 1 }
-    let(:check_response) { [terraform_out, check_err, check_code] }
-    let(:init_err) { "" }
-    let(:init_code) { 0 }
-    let(:init_response) { [terraform_out, init_err, init_code] }
+    let(:terraform_err) { "" }
+    let(:terraform_code) { 0 }
+    let(:terraform_response) { [terraform_out, terraform_err, terraform_code] }
     let(:expected_dir) { File.join(Dir.pwd, dir) }
     let(:opts) { {} }
     let(:success_result) { { stdout: terraform_out } }
-    let(:check_cli) { "terraform providers" }
-    let(:init_cli) { "terraform init -no-color" }
+    let(:terraform_cli) { "terraform init -no-color" }
 
     context "with no options specified" do
       it 'Invokes terraform init with default args' do
-        expect(Open3).to receive(:capture3).with(check_cli).and_return(check_response)
-        expect(Open3).to receive(:capture3).with(init_cli).and_return(init_response)
+        expect(Open3).to receive(:capture3).with(terraform_cli).and_return(terraform_response)
         result = subject.init(opts)
         expect(result).to eq(success_result)
       end
@@ -32,8 +27,7 @@ describe TerraformInitialize do
       let(:opts) { { dir: dir } }
       it 'invokes terraform init with default args from dir relative to cwd' do
         expected_dir = File.expand_path(dir)
-        expect(Open3).to receive(:capture3).with(check_cli, chdir: expected_dir).and_return(check_response)
-        expect(Open3).to receive(:capture3).with(init_cli, chdir: expected_dir).and_return(init_response)
+        expect(Open3).to receive(:capture3).with(terraform_cli, chdir: expected_dir).and_return(terraform_response)
         result = subject.init(opts)
         expect(result).to eq(success_result)
       end

--- a/tasks/initialize.json
+++ b/tasks/initialize.json
@@ -1,0 +1,15 @@
+{
+  "description": "Initialize a Terraform project directory",
+  "files": ["ruby_task_helper/files/task_helper.rb", "terraform/lib/cli_helper.rb"],
+  "input_method": "stdin",
+  "parameters": {
+    "dir": {
+      "type": "Optional[String[1]]",
+      "description": "Path to Terraform project directory. Path is relative to CWD, unless an absolute path is specified."
+    },
+    "reinit": {
+      "type": "Optional[Boolean]",
+      "description": "Parameter that forces the re-initialization of the Terraform project directory"
+    }
+  }
+}

--- a/tasks/initialize.json
+++ b/tasks/initialize.json
@@ -6,10 +6,6 @@
     "dir": {
       "type": "Optional[String[1]]",
       "description": "Path to Terraform project directory. Path is relative to CWD, unless an absolute path is specified."
-    },
-    "reinit": {
-      "type": "Optional[Boolean]",
-      "description": "Parameter that forces the re-initialization of the Terraform project directory"
     }
   }
 }

--- a/tasks/initialize.rb
+++ b/tasks/initialize.rb
@@ -12,26 +12,20 @@ class TerraformInitialize < TaskHelper
     dir = File.expand_path(opts[:dir]) if opts[:dir]
     cli_opts = cli_opts.join(' ')
 
-    _, _, check_init_status = if dir
-                                CliHelper.execute("terraform providers", dir: dir)
-                              else
-                                CliHelper.execute("terraform providers")
-                              end
+    if dir ? Dir.exist?("#{dir}/.terraform") : Dir.exist?(File.expand_path('.terraform'))
+      return { 'stdout': 'Terraform directory already initialized' }
+    end
 
-    if check_init_status != 0 || opts[:reinit]
-      stdout_str, stderr_str, status = if dir
-                                         CliHelper.execute("terraform init #{cli_opts}", dir: dir)
-                                       else
-                                         CliHelper.execute("terraform init #{cli_opts}")
-                                       end
+    stdout_str, stderr_str, status = if dir
+                                       CliHelper.execute("terraform init #{cli_opts}", dir: dir)
+                                     else
+                                       CliHelper.execute("terraform init #{cli_opts}")
+                                     end
 
-      if status == 0
-        { 'stdout': stdout_str }
-      else
-        raise TaskHelper::Error.new(_(stderr_str), 'terraform/init-error')
-      end
+    if status == 0
+      return { 'stdout': stdout_str }
     else
-      { 'stdout': "Terraform directory already initialized" }
+      raise TaskHelper::Error.new(_(stderr_str), 'terraform/init-error')
     end
   end
 

--- a/tasks/initialize.rb
+++ b/tasks/initialize.rb
@@ -1,0 +1,43 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../ruby_task_helper/files/task_helper.rb'
+require_relative '../lib/cli_helper.rb'
+require 'json'
+require 'open3'
+
+class TerraformInitialize < TaskHelper
+  def init(opts)
+    cli_opts = %w[-no-color]
+    dir = File.expand_path(opts[:dir]) if opts[:dir]
+    cli_opts = cli_opts.join(' ')
+
+    _, _, check_init_status = if dir
+                                CliHelper.execute("terraform providers", dir: dir)
+                              else
+                                CliHelper.execute("terraform providers")
+                              end
+
+    if check_init_status != 0 || opts[:reinit]
+      stdout_str, stderr_str, status = if dir
+                                         CliHelper.execute("terraform init #{cli_opts}", dir: dir)
+                                       else
+                                         CliHelper.execute("terraform init #{cli_opts}")
+                                       end
+
+      if status == 0
+        { 'stdout': stdout_str }
+      else
+        raise TaskHelper::Error.new(_(stderr_str), 'terraform/init-error')
+      end
+    else
+      { 'stdout': "Terraform directory already initialized" }
+    end
+  end
+
+  def task(opts)
+    init(opts)
+  end
+end
+
+TerraformInitialize.run if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
	Commit adds a simple task for initializing a Terraform project
	direct to facilitate end-to-end Bolt driven workflows that ship
	and leverage Terraform content for automated infrastructure
	creation