### PR TITLE
Handle case of absent statefile

### DIFF
--- a/spec/tasks/resolve_reference_spec.rb
+++ b/spec/tasks/resolve_reference_spec.rb
@@ -87,9 +87,9 @@ describe Terraform do
       expect(targets).to be_empty
     end
 
-    it 'fails if the state file does not exist' do
-      expect { subject.resolve_reference(opts.merge(state: 'nonexistent.tfstate')) }
-        .to raise_error(/Could not load Terraform state file nonexistent.tfstate/)
+    it 'returns nothing if the state file does not exist' do
+      targets = subject.resolve_reference(opts.merge(state: 'nonexistent.tfstate'))
+      expect(targets).to be_empty
     end
   end
 

--- a/tasks/resolve_reference.rb
+++ b/tasks/resolve_reference.rb
@@ -70,6 +70,9 @@ class Terraform < TaskHelper
   def load_local_statefile(opts)
     filename = opts.fetch(:state, 'terraform.tfstate')
     File.read(File.expand_path(File.join(opts[:dir], filename), opts[:_boltdir]))
+  rescue Errno::ENOENT
+    # No statefile, no resources. Return empty-like state data
+    { 'version' => 4, 'resources' => [], 'outputs' => {} }.to_json
   rescue StandardError => e
     msg = "Could not load Terraform state file #{filename}:\n#{e}"
     raise TaskHelper::Error.new(msg, 'bolt-plugin/validation-error')


### PR DESCRIPTION
The plugin should not crash when the statefile is absent. Rather, it should return no inventory.