### PR TITLE
(maint) Bump maximum Puppet version, prep for 0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Release 0.6.0
+
+### New features
+
+* **Bump maximum Puppet version to include 7.x** ([#22](https://github.com/puppetlabs/puppetlabs-terraform/pull/22))
+
 ## Release 0.5.0
 
 ### New features

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-terraform",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": "Puppet, Inc.",
   "summary": "A task to generate Bolt inventory from Terraform statefiles",
   "license": "Apache-2.0",
@@ -57,7 +57,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.0 < 7.0.0"
+      "version_requirement": ">= 4.10.0 < 8.0.0"
     }
   ],
   "pdk-version": "1.14.0",


### PR DESCRIPTION
Bump the maximum Puppet version to include Puppet 7.x and prep for 0.6.0
release to include that change.