### PR TITLE
(maint) Add PDK as a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Release 0.6.1
+
+### Bug fixes
+
+* **Add PDK as a gem dependency**
+
+  PDK is now a gem dependency for the module release pipeline
+
 ## Release 0.6.0
 
 ### New features

--- a/Gemfile
+++ b/Gemfile
@@ -20,11 +20,12 @@ minor_version = ruby_version_segments[0..1].join('.')
 group :development do
   gem "puppet-module-posix-default-r#{minor_version}", require: false, platforms: [:ruby]
   gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby]
+  gem 'pdk', *location_for(ENV['PDK_GEM_VERSION'])
   gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])
   # Automatic jenkins job to push to forge requires puppet 5 which is incompatible with modern bolt
   if ENV['GEM_BOLT']
     gem 'bolt', '~> 1', require: false
   end
   # Pin puppet blacksmith to avoid failures in forge module push job
-  gem "puppet-blacksmith", "4.1.2"
+  gem 'puppet-blacksmith', '4.1.2'
 end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-terraform",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": "Puppet, Inc.",
   "summary": "A task to generate Bolt inventory from Terraform statefiles",
   "license": "Apache-2.0",


### PR DESCRIPTION
Running the module release pipeline is causing the error `Errno::ENOENT:
No such file or directory - pdk`, which is the same issue described [in
this
commit](puppetlabs/puppetlabs-azure_inventory#11).
Adding PDK as a depedency should ensure that the new release rake task
succeeds.

This also preps to release the update as 0.6.1