### PR TITLE
Provide a refresh task for syncing state without an apply

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 before_install:
 - git clone https://github.com/puppetlabs/puppetlabs-ruby_task_helper ../ruby_task_helper
 - git clone https://github.com/puppetlabs/puppetlabs-ruby_plugin_helper ../ruby_plugin_helper
-- curl -fSL "https://releases.hashicorp.com/terraform/0.12.13/terraform_0.12.13_linux_amd64.zip" -o terraform.zip
+- curl -fSL "https://releases.hashicorp.com/terraform/1.2.8/terraform_1.2.8_linux_amd64.zip" -o terraform.zip
 - sudo unzip terraform.zip -d /opt/terraform
 - sudo ln -s /opt/terraform/terraform /usr/bin/terraform
 - rm -f terraform.zip

--- a/Gemfile
+++ b/Gemfile
@@ -22,9 +22,10 @@ group :development do
   gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby]
   gem 'pdk', *location_for(ENV['PDK_GEM_VERSION'])
   gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])
-  # Automatic jenkins job to push to forge requires puppet 5 which is incompatible with modern bolt
+  # Lock tests to Bolt 3.x to ensure tests do not all immediately fail upon
+  # release of new major version
   if ENV['GEM_BOLT']
-    gem 'bolt', '~> 1', require: false
+    gem 'bolt', '~> 3', require: false
   end
   # Pin puppet blacksmith to avoid failures in forge module push job
   gem 'puppet-blacksmith', '4.1.2'

--- a/plans/apply.pp
+++ b/plans/apply.pp
@@ -1,20 +1,21 @@
 plan terraform::apply(
-  Optional[String[1]] $dir = undef,
-  Optional[String[1]] $state = undef,
-  Optional[String[1]] $state_out = undef,
-  Optional[Variant[String[1], Array[String[1]]]] $target = undef,
-  Optional[Hash] $var = undef,
-  Optional[Variant[String[1], Array[String[1]]]] $var_file = undef,
-  Optional[Boolean] $return_output = false
+  Optional[String[1]]                            $dir           = undef,
+  Optional[String[1]]                            $state         = undef,
+  Optional[String[1]]                            $state_out     = undef,
+  Optional[Variant[String[1], Array[String[1]]]] $target        = undef,
+  Optional[Hash]                                 $var           = undef,
+  Optional[Variant[String[1], Array[String[1]]]] $var_file      = undef,
+  Optional[Boolean]                              $return_output = false,
+  Optional[Boolean]                              $refresh_state = false
 ) {
 
   $apply_opts = {
-    'dir' => $dir,
-    'state' => $state,
+    'dir'       => $dir,
+    'state'     => $state,
     'state_out' => $state_out,
-    'target' => $target,
-    'var' => $var,
-    'var_file' => $var_file
+    'target'    => $target,
+    'var'       => $var,
+    'var_file'  => $var_file
   }
 
   $apply_logs = run_task('terraform::apply', 'localhost', $apply_opts)
@@ -23,11 +24,15 @@ plan terraform::apply(
     return $apply_logs
   }
 
-  $output_opts = {
-    'dir' => $dir,
+  $post_apply_opts = {
+    'dir'   => $dir,
     'state' => $state
   }
 
-  $output = run_task('terraform::output', 'localhost', $output_opts)
+  if $refresh_state {
+    run_task('terraform::refresh', 'localhost', $post_apply_opts)
+  }
+
+  $output = run_task('terraform::output', 'localhost', $post_apply_opts)
   return $output[0].value
 }

--- a/plans/destroy.pp
+++ b/plans/destroy.pp
@@ -1,19 +1,19 @@
 plan terraform::destroy(
-  Optional[String[1]] $dir = undef,
-  Optional[String[1]] $state = undef,
-  Optional[String[1]] $state_out = undef,
-  Optional[Variant[String[1], Array[String[1]]]] $target = undef,
-  Optional[Hash] $var = undef,
-  Optional[Variant[String[1], Array[String[1]]]] $var_file = undef
+  Optional[String[1]]                            $dir       = undef,
+  Optional[String[1]]                            $state     = undef,
+  Optional[String[1]]                            $state_out = undef,
+  Optional[Variant[String[1], Array[String[1]]]] $target    = undef,
+  Optional[Hash]                                 $var       = undef,
+  Optional[Variant[String[1], Array[String[1]]]] $var_file  = undef
 ) {
 
   $opts = {
-    'dir' => $dir,
-    'state' => $state,
+    'dir'       => $dir,
+    'state'     => $state,
     'state_out' => $state_out,
-    'target' => $target,
-    'var' => $var,
-    'var_file' => $var_file
+    'target'    => $target,
+    'var'       => $var,
+    'var_file'  => $var_file
   }
   $result = run_task('terraform::destroy', 'localhost', $opts)
   return $result

--- a/spec/fixtures/docker_provision/docker_provision.tf
+++ b/spec/fixtures/docker_provision/docker_provision.tf
@@ -1,5 +1,16 @@
+terraform {
+  required_providers {
+    docker = {
+      source = "kreuzwerker/docker"
+      version = "~> 2.13.0"
+    }
+  }
+}
+
 # Configure the Docker provider
-provider "docker" {}
+provider "docker" {
+  host = "unix:///var/run/docker.sock"
+}
 
 # Create n sshd servers, map internal ports
 resource "docker_container" "sshd" {

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -34,7 +34,7 @@ describe 'terraform::apply' do
   it "applies terraform manifest and returns logs" do
     result = run_plan('terraform::apply', 'dir' => terraform_dir)
     expect(result['status']).to eq('success')
-    expect(result['value'][0]['result']['stdout'])
+    expect(result['value'][0]['value']['stdout'])
       .to match(/Apply complete! Resources: 2 added, 0 changed, 0 destroyed./)
   end
 

--- a/spec/integration/destroy_spec.rb
+++ b/spec/integration/destroy_spec.rb
@@ -31,7 +31,7 @@ describe 'terraform::destroy' do
   it "destroys Terraform resources" do
     result = run_plan('terraform::destroy', 'dir' => terraform_dir)
     expect(result['status']).to eq('success')
-    expect(result['value'][0]['result']['stdout'])
+    expect(result['value'][0]['value']['stdout'])
       .to match(/Destroy complete! Resources: 2 destroyed./)
   end
 end

--- a/spec/integration/resolve_reference_spec.rb
+++ b/spec/integration/resolve_reference_spec.rb
@@ -83,12 +83,12 @@ describe 'terraform::resolve_reference' do
 
     it 'resolves references from an applied terraform manifest' do
       result = run_task('terraform::resolve_reference', 'localhost', params)
-      expect(result.first['result']).to eq(expected_result)
+      expect(result[0]['value']).to eq(expected_result)
     end
 
     it 'runs a command on a discovered target' do
       result = run_command('whoami', 'terraform', inventory: inventory)
-      expect(result.first['result']['stdout']).to match(/root/)
+      expect(result[0]['value']['stdout']).to match(/root/)
     end
   end
 

--- a/spec/plans/apply_spec.rb
+++ b/spec/plans/apply_spec.rb
@@ -24,15 +24,24 @@ describe "terraform::apply" do
   it 'should return logs when $output is not set' do
     allow_task('terraform::apply').with_params(params).always_return(apply_result)
     result = run_plan('terraform::apply', params)
-    expect(result.value.to_data[0]['result']).to eq(apply_result)
+    expect(result.value[0].value).to eq(apply_result)
   end
 
   it 'should return output when $output is set' do
     plan_params = params.merge('return_output' => true)
-    output_task_params = { 'dir' => 'foo', 'state' => 'foo' }
+    sub_task_params = { 'dir' => 'foo', 'state' => 'foo' }
     allow_task('terraform::apply').with_params(params).always_return(apply_result)
-    allow_task('terraform::output').with_params(output_task_params).always_return(output_result)
+    allow_task('terraform::output').with_params(sub_task_params).always_return(output_result)
     result = run_plan('terraform::apply', plan_params)
     expect(result.value).to eq(output_result)
+  end
+
+  it 'should refresh state when $refresh_state is set' do
+    plan_params = params.merge('refresh_state' => true)
+    sub_task_params = { 'dir' => 'foo', 'state' => 'foo' }
+    allow_task('terraform::apply').with_params(params).always_return(apply_result)
+    allow_task('terraform::refresh').with_params(sub_task_params).always_return(apply_result)
+    result = run_plan('terraform::apply', plan_params).value[0]
+    expect(result.value).to eq(apply_result)
   end
 end

--- a/spec/plans/destroy_spec.rb
+++ b/spec/plans/destroy_spec.rb
@@ -23,6 +23,6 @@ describe "terraform::destroy" do
   it 'should return logs from destroy task' do
     allow_task('terraform::destroy').with_params(params).always_return(destroy_result)
     result = run_plan('terraform::destroy', params)
-    expect(result.value.to_data[0]['result']).to eq(destroy_result)
+    expect(result.value[0].value).to eq(destroy_result)
   end
 end

--- a/spec/tasks/terraform_refresh.rb
+++ b/spec/tasks/terraform_refresh.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../tasks/refresh.rb'
+require 'json'
+
+describe TerraformRefresh do
+  describe "#refresh" do
+    let(:terraform_out) { "Terraform message" }
+    let(:terraform_err) { "" }
+    let(:terraform_code) { 0 }
+    let(:terraform_response) { [terraform_out, terraform_err, terraform_code] }
+    let(:boltdir) { '/boltdir' }
+    let(:expected_dir) { File.join(boltdir, dir) }
+    let(:base_opts) { { _boltdir: boltdir } }
+    let(:additional_opts) { {} }
+    let(:opts) { base_opts.merge(additional_opts) }
+    let(:success_result) { { stdout: terraform_out } }
+    let(:base_cli) { %w[terraform refresh -no-color -json] }
+    let(:additional_cli) { [] }
+    let(:cli) { base_cli.concat(additional_cli).join(' ') }
+
+    context "with no options specified" do
+      it 'Invokes terraform refresh with default args' do
+        expect(Open3).to receive(:capture3).with(cli).and_return(terraform_response)
+        result = subject.output(opts)
+        expect(result).to eq(success_result)
+      end
+    end
+
+    context "with dir option" do
+      let(:dir) { "foo/bar" }
+      let(:additional_opts) { { dir: dir } }
+      it 'invokes terraform refresh with default args from dir relative to boltdir' do
+        expected_dir = File.expand_path(dir, boltdir)
+        expect(Open3).to receive(:capture3).with(cli, chdir: expected_dir).and_return(terraform_response)
+        result = subject.output(opts)
+        expect(result).to eq(success_result)
+      end
+    end
+
+    context "with state option" do
+      let(:state) { "foo.tfstate" }
+      let(:dir) { "foo/bar" }
+      let(:additional_opts) { { state: state, dir: dir } }
+      let(:additional_cli) { ["-state=#{File.join(boltdir, dir, state)}"] }
+      it 'provides abosulute path for state relative to dir' do
+        expect(Open3).to receive(:capture3).with(cli, chdir: expected_dir).and_return(terraform_response)
+        result = subject.output(opts)
+        expect(result).to eq(success_result)
+      end
+    end
+  end
+end

--- a/tasks/refresh.json
+++ b/tasks/refresh.json
@@ -1,0 +1,15 @@
+{
+  "description": "Refresh Terraform state file without doing an apply",
+  "files": ["ruby_task_helper/files/task_helper.rb", "terraform/lib/cli_helper.rb"],
+  "input_method": "stdin",
+  "parameters": {
+    "dir": {
+      "type": "Optional[String[1]]",
+      "description": "Path to Terraform project directory. Path is relative to CWD, unless an absolute path is specified."
+    },
+    "state": {
+      "type": "Optional[String[1]]",
+      "description": "Path to read and save state. Defaults to \"terraform.tfstate\", Path is relative to \"dir\""
+    }
+  }
+}

--- a/tasks/refresh.rb
+++ b/tasks/refresh.rb
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../ruby_task_helper/files/task_helper.rb'
+require_relative '../lib/cli_helper.rb'
+
+class TerraformRefresh < TaskHelper
+  def output(opts)
+    cli_opts = %w[-no-color -json]
+    dir = File.expand_path(opts[:dir]) if opts[:dir]
+    cli_opts << "-state=#{File.expand_path(opts[:state], dir)}" if opts[:state]
+    cli_opts = cli_opts.join(' ')
+
+    stdout_str, stderr_str, status = if dir
+                                       CliHelper.execute("terraform refresh #{cli_opts}", dir: dir)
+                                     else
+                                       CliHelper.execute("terraform refresh #{cli_opts}")
+                                     end
+    if status == 0
+      { 'stdout': stdout_str }
+    else
+      raise TaskHelper::Error.new(stderr_str, 'terraform/refresh-error')
+    end
+  end
+
+  def task(opts)
+    output(opts)
+  end
+end
+
+TerraformOutput.run if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
Sometimes you want to resync state instead of doing an apply to capture modifications to resources which occurred outside of previous Terraform plan run.

...also fixes tests which were found broken