### PR TITLE
Fixes missed rename

### DIFF
--- a/tasks/refresh.rb
+++ b/tasks/refresh.rb
@@ -28,4 +28,4 @@ class TerraformRefresh < TaskHelper
   end
 end
 
-TerraformOutput.run if $PROGRAM_NAME == __FILE__
+TerraformRefresh.run if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
A rename of TerraformOutput to TerraformRefresh was missed when the output.rb task code was re-used.