### PR TITLE
Add var-file parameter to terraform refresh command

### DIFF
--- a/plans/apply.pp
+++ b/plans/apply.pp
@@ -30,7 +30,12 @@ plan terraform::apply(
   }
 
   if $refresh_state {
-    run_task('terraform::refresh', 'localhost', $post_apply_opts + { 'var_file' => $var_file })
+    if $var_file {
+      $refresh_opts = $post_apply_opts + { 'var_file' => $var_file }
+    } else {
+      $refresh_opts = $post_apply_opts
+    }
+    run_task('terraform::refresh', 'localhost', $refresh_opts)
   }
 
   $output = run_task('terraform::output', 'localhost', $post_apply_opts)

--- a/plans/apply.pp
+++ b/plans/apply.pp
@@ -30,7 +30,7 @@ plan terraform::apply(
   }
 
   if $refresh_state {
-    run_task('terraform::refresh', 'localhost', $post_apply_opts)
+    run_task('terraform::refresh', 'localhost', $post_apply_opts + { 'var_file' => $var_file })
   }
 
   $output = run_task('terraform::output', 'localhost', $post_apply_opts)

--- a/tasks/refresh.json
+++ b/tasks/refresh.json
@@ -10,6 +10,10 @@
     "state": {
       "type": "Optional[String[1]]",
       "description": "Path to read and save state. Defaults to \"terraform.tfstate\", Path is relative to \"dir\""
+    },
+    "var_file": {
+      "type": "Optional[Variant[String[1], Array[String[1]]]]",
+      "description": "Set variables in the Terraform configuration from a file. Path is relative to \"dir\". Accepts a single var-file path or an array of paths"
     }
   }
 }

--- a/tasks/refresh.rb
+++ b/tasks/refresh.rb
@@ -9,6 +9,7 @@ class TerraformRefresh < TaskHelper
     cli_opts = %w[-no-color -json]
     dir = File.expand_path(opts[:dir]) if opts[:dir]
     cli_opts << "-state=#{File.expand_path(opts[:state], dir)}" if opts[:state]
+    cli_opts << "-var-file=#{File.expand_path(opts[:var_file], dir)}" if opts[:var_file]
     cli_opts = cli_opts.join(' ')
 
     stdout_str, stderr_str, status = if dir


### PR DESCRIPTION
If a var-file is present, it needs to be added to the `terraform refresh` command. Otherwise, for instance, when using a non-default region, the command will fail.