### PR TITLE
Add `var` and `var_file` params to terraform::refresh

### DIFF
--- a/plans/apply.pp
+++ b/plans/apply.pp
@@ -23,13 +23,19 @@ plan terraform::apply(
     return $apply_logs
   }
 
+  if $refresh_state {
+    $refresh_opts = {
+      'dir'      => $dir,
+      'state'    => $state,
+      'var'      => $var,
+      'var_file' => $var_file,
+    }
+    run_task('terraform::refresh', 'localhost', $refresh_opts)
+  }
+
   $post_apply_opts = {
     'dir'   => $dir,
     'state' => $state,
-  }
-
-  if $refresh_state {
-    run_task('terraform::refresh', 'localhost', $post_apply_opts)
   }
 
   $output = run_task('terraform::output', 'localhost', $post_apply_opts)

--- a/spec/unit/plans/apply_spec.rb
+++ b/spec/unit/plans/apply_spec.rb
@@ -38,7 +38,7 @@ describe 'terraform::apply' do
 
   it 'refreshes state when $refresh_state is set' do
     plan_params = params.merge('refresh_state' => true)
-    sub_task_params = { 'dir' => 'foo', 'state' => 'foo' }
+    sub_task_params = { 'dir' => 'foo', 'state' => 'foo', 'var' => 'foo', 'var_file' => 'foo' }
     allow_task('terraform::apply').with_params(params).always_return(apply_result)
     allow_task('terraform::refresh').with_params(sub_task_params).always_return(apply_result)
     result = run_plan('terraform::apply', plan_params).value[0]


### PR DESCRIPTION
This PR adds the `var` and `var_file` parameters to the `terraform::refresh` task invocation when called from the `terraform::apply` plan.

My previous PR #29 was meant to address this issue but it was closed and superseded by the PR #30 . However, that PR didn't include the change in the `terraform::apply` plan which was also needed.