### PR TITLE
(maint) Bump ruby_task_helper dependency for Puppet 8

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-ruby_task_helper",
-      "version_requirement": ">= 0.1.0 < 1.0.0"
+      "version_requirement": ">= 0.1.0 <= 1.0.0"
     },
     {
       "name": "puppetlabs-ruby_plugin_helper",

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-ruby_task_helper",
-      "version_requirement": ">= 0.1.0 <= 1.0.0"
+      "version_requirement": ">= 0.1.0 < 2.0.0"
     },
     {
       "name": "puppetlabs-ruby_plugin_helper",


### PR DESCRIPTION
The puppetlabs-terraform module was bumped to allow Puppet 8 in 0.7.1, but it still depends on puppetlabs-ruby_task_helper < 1.0 which is locked to Puppet 7. The puppetlabs-ruby_task_helper module opened up to Puppet 8 in its 1.0 release.